### PR TITLE
fix package.json w/ correct license value

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "dist"
   ],
   "author": "bdehamer@github.com",
-  "license": "ISC",
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/github/sigstore-node/issues"
   },


### PR DESCRIPTION
Make sure `license` value in package.json agrees w/ LICENSE file in repository